### PR TITLE
Adds slack badges to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Slack badge in documentation
 - Updated base images to 2017.9.g
 - Refactored module to replace duplicated policies by inline policies
 - Replace resources to remove deprecated warnins

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ We'd love for you to contribute to our source code and to make the Forest even b
  - [Issues and Bugs](#issue)
  - [Feature Requests](#feature)
  - [Submission Guidelines](#submit)
- - [Coding Rules](#rules)
- - [Commit Message Guidelines](#commit)
  - [Further Info](#info)
 
 ## <a name="question"></a> Got a Question or Problem?
 
 If you have questions about how to use the Forest, please direct these to the [Slack group / philips-software][slack].
+
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
 
 ## <a name="issue"></a> Found an Issue?
 
@@ -124,6 +124,14 @@ from the main (upstream) repository:
     ```shell
     git pull --ff upstream master
     ```
+
+## <a name="info"></a> Info
+
+For more info, please reach out to the team on [Slack group / philips-software][slack] in the #forest channel.
+
+Use the badge to sign-up.
+
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
 
 [contribute]: CONTRIBUTING.md
 [github]: https://github.com/philips-software/terraform-aws-ecs/issues 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The MIT License (MIT) Copyright © [2018] Koninklijke Philips N.V, https://www.philips.com
+The MIT License (MIT) Copyright © 2018 Koninklijke Philips N.V, https://www.philips.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -71,3 +71,21 @@ data "template_file" "ecs-instance-template" {
 | id | Id of the cluster. |
 | name | Name of the cluster. |
 | service_role_name | Created IAM service role name. |
+
+## Philips Forest
+
+This module is part of the Philips Forest.
+
+```
+                                                     ___                   _
+                                                    / __\__  _ __ ___  ___| |_
+                                                   / _\/ _ \| '__/ _ \/ __| __|
+                                                  / / | (_) | | |  __/\__ \ |_
+                                                  \/   \___/|_|  \___||___/\__|  
+
+                                                                 Infrastructure
+```
+
+Talk to the forestkeepers in the `forest`-channel on Slack.
+
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)


### PR DESCRIPTION
Add Slack Badge to enable faster communication with developers.

Keep documentation in line with: https://github.com/philips-software/terraform-aws-vpc/pull/1