### PR TITLE
Support udp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
@@ -6,30 +7,40 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Allow all types of traffic within VPC instead of only TCP
+- Add variable `additional_cidr_blocks` to whitelist extra CIDR blocks within VPC
+
 ### Changed
 
 ## 2.0.0
+
 - Upgrade to terraform 0.12
 - Moved from travis-ci to Github Actions
 
 ## 1.4.0
+
 - Add policies to allow dynamic scaling
-- Changed: (Breaking change) The default ECS image is changed to the latest amazon linux2 ami available at the time the terraform script is running. To ensure the version is fixed, provide the filter variable with to select an ami. See the [readme][README.md] for more details
+- Changed: (Breaking change) The default ECS image is changed to the latest amazon linux2 ami available at the time the terraform script is running. To ensure the version is fixed, provide the filter variable with to select an ami. See the [readme][readme.md] for more details
 
 ## 1.3.0
+
 - Update default base images to 2018.03.e
 
 ## 1.2.0
+
 - Add a second, more advanced example.
 
 ## 1.1.0
+
 https://github.com/philips-software/terraform-aws-ecs/tags/1.1.0
+
 - Add extra input variable tags, for tagging resources
 - Add extra output variables iam_instance_profile_arn and instance_sg_id
 
-
 ## 1.0.0
+
 https://github.com/philips-software/terraform-aws-ecs/tags/1.0.0
+
 - Update naming of the autoscaling group to be consistent with the other naming conventions.
 - Slack badge in documentation
 - Updated base images to 2017.9.g
@@ -40,7 +51,8 @@ https://github.com/philips-software/terraform-aws-ecs/tags/1.0.0
 - Renamed output variables
 - Update of ECS optimized AMI's
 
-[Unreleased]: https://github.com/philips-software/terraform-aws-ecs/compare/2..0...HEAD
+[unreleased]: https://github.com/philips-software/terraform-aws-ecs/compare/2..0...HEAD
+
 [2.0.0] https://github.com/philips-software/terraform-aws-ecscompare/1.4.0...2.0.0
 [1.4.0] https://github.com/philips-software/terraform-aws-ecscompare/1.3.0...1.4.0
 [1.3.0] https://github.com/philips-software/terraform-aws-ecscompare/1.2.0...1.3.0

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Terraform module for creating a ecs cluster
+
 ![badge](https://action-badges.now.sh/philips-software/terraform-aws-ecs)
 
 This [Terraform module]() creates a ECS container cluster in Amazon. Prerequisite is to have a a VPC available. The VPC can be create via the official verified [AWS VPC module](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/1.37.0), or via the our own [VPC](https://github.com/philips-software/terraform-aws-vpc) module.
 
 The module creates a ECS cluster by default using one EC2 instance. No auto scaling is configured, currently scaling can only be done by change parameters, see examples below.
 
-*Note:* Release 1.4.0 contains the following backwards incompatible changes
-- Default ECS AMI is from now on the latest Amazon linux available at the time terraform is executed. The AMI version can be fixed by setting the filter variable: `ecs_ami_filter`, see the example below. Functional the change can be implemented backwards compatible by setting the filter to the image that you was using before the upgrade.
+_Note:_ Release 1.4.0 contains the following backwards incompatible changes
 
+- Default ECS AMI is from now on the latest Amazon linux available at the time terraform is executed. The AMI version can be fixed by setting the filter variable: `ecs_ami_filter`, see the example below. Functional the change can be implemented backwards compatible by setting the filter to the image that you was using before the upgrade.
 
 ## Terraform version
 
@@ -15,10 +16,12 @@ The module creates a ECS cluster by default using one EC2 instance. No auto scal
 - Terraform 0.11: Pin module to `~> 1.x`, submit pull request to branch `terrafomr012`
 
 ## Examples
+
 - [ECS cluster basic](examples/ecs-cluster-advanced) - This examples combines the usage of the VPC module, ECS cluster (this module), ECS service module, centralized logging.
 - [ECS cluster advanced](examples/ecs-cluster-advanced) - A slightly more advanced example. This examples combines the usage of the AWS VPC module, ECS cluster (this module), ECS service module, centralized logging and monitoring.
 
 ## Usage
+
 Below an example usages. Complete examples are provided in the `examples` directory.
 
 ```
@@ -59,53 +62,60 @@ data "template_file" "ecs-instance-template" {
 }
 ```
 
-| Name                         | Description                                                                                                                                         |       Type        |  Default  | Required |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------: | :-------: | :------: |
-| aws\_region                  | The Amazon region: currently North Virginia [us-east-1].                                                                                            |      string       |    n/a    |   yes    |
-| desired\_instance\_count     | The desired instance count in the cluster.                                                                                                          |      number       |   `"1"`   |    no    |
-| dynamic\_scaling             | Enable/disable dynamic scaling of the auto scaling group.                                                                                           |       bool        | `"false"` |    no    |
-| dynamic\_scaling\_adjustment | The adjustment in number of instances for dynamic scaling.                                                                                          |      number       |   `"1"`   |    no    |
-| ecs\_ami\_filter             | The filter used to select the AMI for the ECS cluster. By default the the pattern `amzn2-ami-ecs-hvm-2.0.????????-x86_64-ebs` for the name is used. | list(map(string)) | `<list>`  |    no    |
-| ecs\_ami\_latest             | Indicator to use the latest avaiable in the the list of the AMI's for the ECS cluster.                                                              |       bool        | `"true"`  |    no    |
-| ecs\_ami\_owners             | A list of owners used to select the AMI for the ECS cluster.                                                                                        |   list(string)    | `<list>`  |    no    |
-| ecs\_optimized\_type         | Possible values                                                                                                                                     |      string       | `"amzn2"` |    no    |
-| environment                  | Name of the environment; will be prefixed to all resources.                                                                                         |      string       |    n/a    |   yes    |
-| instance\_type               | The instance type used in the cluster.                                                                                                              |      string       |    n/a    |   yes    |
-| key\_name                    | The AWS keyname, used to create instances.                                                                                                          |      string       |    n/a    |   yes    |
-| max\_instance\_count         | The maximum instance count in the cluster.                                                                                                          |      number       |   `"1"`   |    no    |
-| min\_instance\_count         | The minimal instance count in the cluster.                                                                                                          |      number       |   `"1"`   |    no    |
-| project                      | Project identifier                                                                                                                                  |      string       |    n/a    |   yes    |
-| subnet\_ids                  | List of subnets ids on which the instances will be launched.                                                                                        |      string       |    n/a    |   yes    |
-| tags                         | Map of tags to apply on the resources                                                                                                               |    map(string)    |  `<map>`  |    no    |
-| user\_data                   | The user-data for the ec2 instances                                                                                                                 |      string       |    n/a    |   yes    |
-| vpc\_cidr                    | The CIDR block of the VPC (e.g. 10.64.48.0/23).                                                                                                     |      string       |    n/a    |   yes    |
-| vpc\_id                      | The VPC to launch the instance in (e.g. vpc-66ecaa02).                                                                                              |      string       |    n/a    |   yes    |
+## Inputs
+
+| Name                       | Description                                                                                                                                         | Type                | Default                                                                                                     | Required |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------- | :------: |
+| additional_cidr_blocks     | Additional CIDR blocks that will be whitelisted within the VPC next to the VPC's CIDR block. Default is an empty list.                              | `list`              | `[]`                                                                                                        |    no    |
+| aws_region                 | The Amazon region: currently North Virginia [us-east-1].                                                                                            | `string`            | n/a                                                                                                         |   yes    |
+| desired_instance_count     | The desired instance count in the cluster.                                                                                                          | `number`            | `1`                                                                                                         |    no    |
+| dynamic_scaling            | Enable/disable dynamic scaling of the auto scaling group.                                                                                           | `bool`              | `false`                                                                                                     |    no    |
+| dynamic_scaling_adjustment | The adjustment in number of instances for dynamic scaling.                                                                                          | `number`            | `1`                                                                                                         |    no    |
+| ecs_ami_filter             | The filter used to select the AMI for the ECS cluster. By default the the pattern `amzn2-ami-ecs-hvm-2.0.????????-x86_64-ebs` for the name is used. | `list(map(string))` | <pre>[<br> {<br> "name": "name",<br> "values": "amzn2-ami-ecs-hvm-2.0.????????-x86_64-ebs"<br> }<br>]</pre> |    no    |
+| ecs_ami_latest             | Indicator to use the latest avaiable in the the list of the AMI's for the ECS cluster.                                                              | `bool`              | `true`                                                                                                      |    no    |
+| ecs_ami_owners             | A list of owners used to select the AMI for the ECS cluster.                                                                                        | `list(string)`      | <pre>[<br> "amazon"<br>]</pre>                                                                              |    no    |
+| ecs_optimized_type         | Possible values                                                                                                                                     | `string`            | `"amzn2"`                                                                                                   |    no    |
+| environment                | Name of the environment; will be prefixed to all resources.                                                                                         | `string`            | n/a                                                                                                         |   yes    |
+| instance_type              | The instance type used in the cluster.                                                                                                              | `string`            | n/a                                                                                                         |   yes    |
+| key_name                   | The AWS keyname, used to create instances.                                                                                                          | `string`            | n/a                                                                                                         |   yes    |
+| max_instance_count         | The maximum instance count in the cluster.                                                                                                          | `number`            | `1`                                                                                                         |    no    |
+| min_instance_count         | The minimal instance count in the cluster.                                                                                                          | `number`            | `1`                                                                                                         |    no    |
+| project                    | Project identifier                                                                                                                                  | `string`            | n/a                                                                                                         |   yes    |
+| subnet_ids                 | List of subnets ids on which the instances will be launched.                                                                                        | `string`            | n/a                                                                                                         |   yes    |
+| tags                       | Map of tags to apply on the resources                                                                                                               | `map(string)`       | `{}`                                                                                                        |    no    |
+| user_data                  | The user-data for the ec2 instances                                                                                                                 | `string`            | n/a                                                                                                         |   yes    |
+| vpc_cidr                   | The CIDR block of the VPC (e.g. 10.64.48.0/23).                                                                                                     | `string`            | n/a                                                                                                         |   yes    |
+| vpc_id                     | The VPC to launch the instance in (e.g. vpc-66ecaa02).                                                                                              | `string`            | n/a                                                                                                         |   yes    |
 
 ## Outputs
 
-| Name                               | Description                                     |
-| ---------------------------------- | ----------------------------------------------- |
-| autoscaling\_group\_name           | Created auto scaling group for cluster.         |
-| autoscaling\_policy\_scaleIn\_arn  | Created auto scaling group policy for scaleIn.  |
-| autoscaling\_policy\_scaleOut\_arn | Created auto scaling group policy for scaleOut. |
-| iam\_instance\_profile\_arn        | Created IAM instance profile.                   |
-| id                                 | Id of the cluster.                              |
-| instance\_sg\_id                   | Created security group for cluster instances.   |
-| name                               | Name of the cluster.                            |
-| service\_role\_name                | Created IAM service role name.                  |
-
+| Name                            | Description                                     |
+| ------------------------------- | ----------------------------------------------- |
+| autoscaling_group_name          | Created auto scaling group for cluster.         |
+| autoscaling_policy_scaleIn_arn  | Created auto scaling group policy for scaleIn.  |
+| autoscaling_policy_scaleOut_arn | Created auto scaling group policy for scaleOut. |
+| iam_instance_profile_arn        | Created IAM instance profile.                   |
+| id                              | Id of the cluster.                              |
+| instance_sg_id                  | Created security group for cluster instances.   |
+| name                            | Name of the cluster.                            |
+| service_role_name               | Created IAM service role name.                  |
 
 ## Automated checks
+
 Currently the automated checks are limited. In CI the following checks are done for the root and each example.
+
 - lint: `terraform validate` and `terraform fmt`
 - basic init / get check: `terraform init -get -backend=false -input=false`
 
 ## Automated checks
+
 Currently the automated checks are limited. In CI the following checks are done for the root and each example.
+
 - lint: `terraform validate` and `terraform fmt`
 - basic init / get check: `terraform init -get -backend=false -input=false`
 
 ## Generation variable documentation
+
 A markdown table for variables can be generated as follow. Generation requires awk and terraform-docs installed.
 
 ```
@@ -121,7 +131,7 @@ This module is part of the Philips Forest.
                                                     / __\__  _ __ ___  ___| |_
                                                    / _\/ _ \| '__/ _ \/ __| __|
                                                   / / | (_) | | |  __/\__ \ |_
-                                                  \/   \___/|_|  \___||___/\__|  
+                                                  \/   \___/|_|  \___||___/\__|
 
                                                                  Infrastructure
 ```

--- a/main.tf
+++ b/main.tf
@@ -118,9 +118,7 @@ resource "aws_security_group" "instance_sg" {
     from_port = 0
     to_port   = 0
 
-    cidr_blocks = [
-      var.vpc_cidr,
-    ]
+    cidr_blocks = concat([var.vpc_cidr], var.additional_cidr_blocks)
   }
 
   egress {

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "aws_security_group" "instance_sg" {
   vpc_id      = var.vpc_id
 
   ingress {
-    protocol  = "tcp"
+    protocol  = "-1"
     from_port = 0
     to_port   = 65535
 
@@ -126,7 +126,7 @@ resource "aws_security_group" "instance_sg" {
   egress {
     from_port   = 0
     to_port     = 65535
-    protocol    = "tcp"
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,7 @@ resource "aws_security_group" "instance_sg" {
   ingress {
     protocol  = "-1"
     from_port = 0
-    to_port   = 65535
+    to_port   = 0
 
     cidr_blocks = [
       var.vpc_cidr,
@@ -125,7 +125,7 @@ resource "aws_security_group" "instance_sg" {
 
   egress {
     from_port   = 0
-    to_port     = 65535
+    to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "vpc_cidr" {
   type        = string
 }
 
+variable "additional_cidr_blocks" {
+  description = "Additional CIDR blocks that will be whitelisted within the VPC next to the VPC's CIDR block. Default is an empty list."
+  type        = list
+  default     = []
+}
+
 variable "min_instance_count" {
   description = "The minimal instance count in the cluster."
   type        = number


### PR DESCRIPTION
- Allow all types of traffic within VPC instead of only TCP
- Add variable `additional_cidr_blocks` to whitelist extra CIDR blocks within VPC
