### PR TITLE
Added session manager support to ecs instance role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Added session manager support to ecs instance role
 
 ### Changed
 

--- a/main.tf
+++ b/main.tf
@@ -196,6 +196,5 @@ resource "aws_iam_role_policy" "ecs_instance" {
 resource "aws_iam_role_policy_attachment" "ecs_instance" {
   role       = aws_iam_role.ecs_instance.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-  count      = var.enable_session_manager == "true" ? 1 : 0
 }
 

--- a/main.tf
+++ b/main.tf
@@ -196,5 +196,6 @@ resource "aws_iam_role_policy" "ecs_instance" {
 resource "aws_iam_role_policy_attachment" "ecs_instance" {
   role       = aws_iam_role.ecs_instance.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  count      = var.enable_session_manager == "true" ? 1 : 0
 }
 

--- a/main.tf
+++ b/main.tf
@@ -196,6 +196,6 @@ resource "aws_iam_role_policy" "ecs_instance" {
 resource "aws_iam_role_policy_attachment" "ecs_instance" {
   role       = aws_iam_role.ecs_instance.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-  count      = var.enable_session_manager == "true" ? 1 : 0
+  count      = var.enable_session_manager == true ? 1 : 0
 }
 

--- a/main.tf
+++ b/main.tf
@@ -193,3 +193,8 @@ resource "aws_iam_role_policy" "ecs_instance" {
   policy = data.template_file.instance_profile.rendered
 }
 
+resource "aws_iam_role_policy_attachment" "ecs_instance" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,7 @@ variable "dynamic_scaling" {
 variable "enable_session_manager" {
   description = "Enable/disable aws session manager support (i.e remote access to instance in VPC using secure tunnel)."
   type        = bool
+  default     = false
 }
 
 variable "dynamic_scaling_adjustment" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,12 @@ variable "dynamic_scaling" {
   default     = false
 }
 
+variable "enable_session_manager" {
+  description = "Enable/disable aws session manager support (i.e remote access to instance in VPC using secure tunnel)."
+  type        = bool
+  default     = false
+}
+
 variable "dynamic_scaling_adjustment" {
   description = "The adjustment in number of instances for dynamic scaling."
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,6 @@ variable "dynamic_scaling" {
 variable "enable_session_manager" {
   description = "Enable/disable aws session manager support (i.e remote access to instance in VPC using secure tunnel)."
   type        = bool
-  default     = false
 }
 
 variable "dynamic_scaling_adjustment" {


### PR DESCRIPTION
In order to securely access the ecs instances using the aws cli session manager plugin, a policy needs to be added to the instance role.